### PR TITLE
Add argtype fetching

### DIFF
--- a/arguments.lisp
+++ b/arguments.lisp
@@ -167,4 +167,4 @@ Returns return type (or :unknown) as a second value."
            (values (second ftype) (or (third ftype) :unknown))
            (values :unknown :unknown)))
      #-(or cmucl scl sbcl ecl gcl clozure abcl allegro)
-     nil)))
+     (values :unknown :unknown))))


### PR DESCRIPTION
Closes #9 

Several design decisions here:
- Return type is returned as a second value so that it's somewhat hidden as something not entirely consistent with the library purpose.
- Unknown types are returned as `:unknown`. An alternative would be to replace all of them with `T`, but I decided to go with `:unknown` for consistency.
- MOP functions are used to enable method specializer fetching.