### PR TITLE
Support method lambda lists.

### DIFF
--- a/arguments.lisp
+++ b/arguments.lisp
@@ -19,7 +19,8 @@
    #+mezzano   #:mezzano.clos
    #+sicl      #:sicl-clos
    #:method-generic-function
-   #:method-specializers))
+   #:method-specializers
+   #:method-lambda-list))
 (in-package #:org.shirakumo.trivial-arguments)
 
 #-(or :abcl :allegro :ccl :clasp :clisp :cmucl :corman :ecl :lispworks :mezzano :sbcl :scl)
@@ -32,76 +33,78 @@
 (defun arglist (function)
   "Returns the lambda-list of the function if possible, :unknown otherwise."
   (let ((function (etypecase function
-                    ((or list symbol function) function))))
-    #+:abcl
-    (multiple-value-bind (list provided) (sys::arglist function)
-      (if provided list :unknown))
+                    ((or list symbol function standard-method) function))))
+    (if (typep function 'standard-method)
+        (method-lambda-list function)
+        #+:abcl
+        (multiple-value-bind (list provided) (sys::arglist function)
+          (if provided list :unknown))
 
-    #+:allegro
-    (with-unknown-on-error
-      (excl:arglist function))
+        #+:allegro
+        (with-unknown-on-error
+          (excl:arglist function))
 
-    #+:ccl
-    (multiple-value-bind (list provided) (ccl:arglist function)
-      (if provided list :unknown))
+        #+:ccl
+        (multiple-value-bind (list provided) (ccl:arglist function)
+          (if provided list :unknown))
 
-    #+:clasp
-    (multiple-value-bind (list provided) (core:function-lambda-list function)
-      (if provided list :unknown))
+        #+:clasp
+        (multiple-value-bind (list provided) (core:function-lambda-list function)
+          (if provided list :unknown))
 
-    #+:clisp
-    (with-unknown-on-error
-      (ext:arglist function))
+        #+:clisp
+        (with-unknown-on-error
+          (ext:arglist function))
 
-    #+:cmucl
-    (with-unknown-on-error
-      (cond ((eval:interpreted-function-p function)
-             (eval:interpreted-function-arglist function))
-            ((pcl::generic-function-p function)
-             (pcl:generic-function-lambda-list function))
-            ((c::byte-function-or-closure-p function)
-             (byte-code-function-arglist function))
-            ((kernel:%function-arglist (kernel:%function-self function))
-             (read-arglist function))
-            (T
-             (debug-function-arglist (di::function-debug-function function)))))
+        #+:cmucl
+        (with-unknown-on-error
+          (cond ((eval:interpreted-function-p function)
+                 (eval:interpreted-function-arglist function))
+                ((pcl::generic-function-p function)
+                 (pcl:generic-function-lambda-list function))
+                ((c::byte-function-or-closure-p function)
+                 (byte-code-function-arglist function))
+                ((kernel:%function-arglist (kernel:%function-self function))
+                 (read-arglist function))
+                (T
+                 (debug-function-arglist (di::function-debug-function function)))))
 
-    #+:corman
-    (with-unknown-on-error
-      (cond ((and (symbolp function) (macro-function function))
-             (ccl::macro-lambda-list (symbol-function function)))
-            (T
-             (when (symbolp function)
-               (setf function (symbol-function function)))
-             (if (eq (class-of name) cl::the-class-standard-gf)
-                 (generic-function-lambda-list name)
-                 (ccl:function-lambda-list name)))))
+        #+:corman
+        (with-unknown-on-error
+          (cond ((and (symbolp function) (macro-function function))
+                 (ccl::macro-lambda-list (symbol-function function)))
+                (T
+                 (when (symbolp function)
+                   (setf function (symbol-function function)))
+                 (if (eq (class-of name) cl::the-class-standard-gf)
+                     (generic-function-lambda-list name)
+                     (ccl:function-lambda-list name)))))
 
-    #+:ecl
-    (multiple-value-bind (list provided) (ext:function-lambda-list function)
-      (if provided list :unknown))
+        #+:ecl
+        (multiple-value-bind (list provided) (ext:function-lambda-list function)
+          (if provided list :unknown))
 
-    #+:lispworks
-    (let ((list (lw:function-lambda-list function)))
-      (if (eq list :dont-know) :unknown list))
+        #+:lispworks
+        (let ((list (lw:function-lambda-list function)))
+          (if (eq list :dont-know) :unknown list))
 
-    #+mezzano
-    (with-unknown-on-error
-      (mezzano.debug:function-lambda-list function))
+        #+mezzano
+        (with-unknown-on-error
+          (mezzano.debug:function-lambda-list function))
 
-    #+:sbcl
-    (multiple-value-bind (list unknown) (sb-introspect:function-lambda-list function)
-      (if unknown :unknown list))
+        #+:sbcl
+        (multiple-value-bind (list unknown) (sb-introspect:function-lambda-list function)
+          (if unknown :unknown list))
 
-    #+:scl
-    (multiple-value-bind (list provided) (ext:function-arglist function)
-      (if provided list :unknown))
+        #+:scl
+        (multiple-value-bind (list provided) (ext:function-arglist function)
+          (if provided list :unknown))
 
-    #-(or :abcl :allegro :ccl :clasp :clisp :cmucl :corman :ecl :lispworks :mezzano :sbcl :scl)
-    (let ((lambda (function-lambda-expression (etypecase function
-                                                ((or list symbol) (fdefinition function))
-                                                (function function)))))
-      (if lambda (second lambda) :unknown))))
+        #-(or :abcl :allegro :ccl :clasp :clisp :cmucl :corman :ecl :lispworks :mezzano :sbcl :scl)
+        (let ((lambda (function-lambda-expression (etypecase function
+                                                    ((or list symbol) (fdefinition function))
+                                                    (function function)))))
+          (if lambda (second lambda) :unknown)))))
 
 (defun argtypes (function)
   "Returns the argument types for the function or :unknown.


### PR DESCRIPTION
This allows getting method lambda lists (these often have argument names quite different to these of the generic function and thus meaningful) with `arglist`.

Try it on:
```
(trivial-arguments:arglist (nth X (closer-mop:generic-function-methods #'print-object)))
```